### PR TITLE
update to work with mockr 0.2.0

### DIFF
--- a/tests/testthat/test-with-mock.r
+++ b/tests/testthat/test-with-mock.r
@@ -13,87 +13,87 @@ test_environment <- environment()
 
 test_that('Testing "returns" case using with_mock', {
   skip_if_no_mockr()
-  
+
   stub_builder <- stub(sub)
   stub_builder$returns('hang on')
   sub_stub <- stub_builder$f
-  
-  file_path_sans_ext_tester <- function(x) with_mock(sub = sub_stub, file_path_sans_ext(x), .env = test_environment)
-  
+
+  file_path_sans_ext_tester <- function(x) with_mock(sub = sub_stub, { file_path_sans_ext(x) }, .env = test_environment)
+
   expect_equal(object = file_path_sans_ext_tester('test5'),
                expected = 'hang on')
 })
 
 test_that('Testing "throws" case using with_mock', {
   skip_if_no_mockr()
-  
+
   stub_builder <- stub(sub)
   stub_builder$throws('kkkkkkkkkk')
   sub_stub <- stub_builder$f
-  
-  file_path_sans_ext_tester <- function(x) with_mock(sub = sub_stub, file_path_sans_ext(x), .env = test_environment)
-  
+
+  file_path_sans_ext_tester <- function(x) with_mock(sub = sub_stub, { file_path_sans_ext(x) }, .env = test_environment)
+
   expect_error(file_path_sans_ext_tester('dsfsd'),  'kkkkkkkkkk')
   expect_error(file_path_sans_ext_tester('gfgxgx'), 'kkkkkkkkkk')
 })
 
 test_that('Testing "expects" case using with_mock', {
   skip_if_no_mockr()
-  
+
   stub_builder <- stub(sub)
   stub_builder$strictlyExpects(pattern = "([^.]+)\\.[[:alnum:]]+$", replacement = '\\1', x = 'goo.goo',
                                ignore.case = FALSE, perl = FALSE, fixed = FALSE, useBytes = FALSE)
   sub_stub <- stub_builder$f
-  
-  file_path_sans_ext_tester <- function(x) with_mock(sub = sub_stub, file_path_sans_ext(x), .env = test_environment)
-  
+
+  file_path_sans_ext_tester <- function(x) with_mock(sub = sub_stub, { file_path_sans_ext(x) }, .env = test_environment)
+
   expect_error(file_path_sans_ext_tester('dsfsd'))
   expect_silent(file_path_sans_ext_tester('goo.goo'))
 })
 
 test_that('Testing non-simple cases using with_mock', {
   skip_if_no_mockr()
-  
+
   stub_builder <- stub(sub)
-  
+
   stub_builder$onCall(1)$returns('yay!')
-  
+
   stub_builder$onCall(2)$strictlyExpects(
     pattern = "([^.]+)\\.[[:alnum:]]+$", replacement = '\\1', x = 'test2',
     ignore.case = FALSE, perl = FALSE, fixed = FALSE, useBytes = FALSE)$returns(10)
-  
+
   stub_builder$onCall(3)$strictlyExpects(
     pattern = "([^.]+)\\.[[:alnum:]]+$", replacement = '\\1', x = 'test3',
     ignore.case = FALSE, perl = FALSE, fixed = FALSE, useBytes = FALSE)$throws('err msg')
-  
+
   stub_builder$onCall(4)$expects(x = 'test4')$returns('test4-res')
-  
+
   stub_builder$withExactArgs(
     pattern = "[.](gz|bz2|xz)$", replacement = '', x = 'test5',
     ignore.case = FALSE, perl = FALSE, fixed = FALSE, useBytes = FALSE)$throws('test5-res')
-  
+
   stub_builder$withArgs(x = 'test67')$returns('test67-res')
-  
+
   stub_builder$withArgs(x = 'test67-res')$returns('test67-res-res')
-  
+
   sub_stub <- stub_builder$f
-  
+
   file_path_sans_ext_tester <- function(x, compression = FALSE) {
-    with_mock(sub = sub_stub, file_path_sans_ext(x, compression = compression), .env = test_environment) 
+    with_mock(sub = sub_stub, { file_path_sans_ext(x, compression = compression) }, .env = test_environment)
   }
-  
+
   expect_equal(file_path_sans_ext_tester('dsfsdfs.gfg'), 'yay!')
-  
+
   expect_equal(file_path_sans_ext_tester('test2'), 10)
-  
+
   expect_error(file_path_sans_ext_tester('test3'), 'err msg')
-  
+
   expect_equal(file_path_sans_ext_tester('test4'), 'test4-res')
-  
+
   expect_error(file_path_sans_ext_tester('test5', compression = TRUE), 'test5-res')
-  
+
   expect_equal(file_path_sans_ext_tester('test67'), 'test67-res')
-  
+
   expect_equal(file_path_sans_ext_tester('test67', compression = TRUE), 'test67-res-res')
-  
+
 })


### PR DESCRIPTION
Addresses #8 

stubthat is dependent on mockr, which saw a breaking release in April 2022.

https://github.com/krlmlr/mockr/blob/db92a5d406271d80191288be576ced280807f121/NEWS.md

> with_mock() now requires braces (so that error locations can be reported more accurately) and supports only one expression (#15).

This updates test-with-mock.r to match. There's only test that actually fails, an `expect_silent` assertion, because of this breaking change.

```
> devtools::test()
ℹ Loading stubthat
ℹ Testing stubthat
✓ |  OK F W S | Context
✓ |   2       | called-times                                                                                                                                                      
✓ |   4       | function-as-arg [0.1 s]                                                                                                                                           
✓ |  16       | on-call-expects                                                                                                                                                   
✓ |  14       | on-call-strictly-expects                                                                                                                                          
✓ |   9       | on-call                                                                                                                                                           
✓ |  57       | simple-cases [0.2 s]                                                                                                                                              
✓ |  16       | with-args                                                                                                                                                         
✓ |  20       | with-exact-args                                                                                                                                                   
✓ |  12       | with-mock                                                                                                                                                         

══ Results ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 0.6 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 150 ]
```